### PR TITLE
Check the state of the workers to get really connected

### DIFF
--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -67,12 +67,12 @@ class AutoWorker(object):
         self.queue = queue_class(queue, connection=self.connection)
 
     def num_connected_workers(self):
-        return len(
+        return len([
             w for w in Worker.all(queue=self.queue) if w.state in (
                 WorkerStatus.STARTED, WorkerStatus.SUSPENDED, WorkerStatus.BUSY,
                 WorkerStatus.IDLE
             )
-        )
+        ])
 
     def worker(self):
         """Internal target to use in multiprocessing


### PR DESCRIPTION
We were using `Worker.count(queue=queue)` to get the connected workers, but sometimes the key of the worker is set on the redis but the worker isn't real, and the state of that worker is '?'. Then we implemented a method to get the real connected workers checking the state of the worker