### PR TITLE
FIX set default job ttl as rq's registry ttl

### DIFF
--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -43,7 +43,7 @@ class AutoWorker(object):
     :param max_procs: Number of max_procs to spawn
     """
     def __init__(self, queue=None, max_procs=None, skip_failed=True,
-                 default_result_ttl=None):
+                 default_result_ttl=0):
         if queue is None:
             queue = 'default'
         if max_procs is None:


### PR DESCRIPTION
- FIX set default job ttl as rq's registry ttl

From rq's registry add: https://github.com/rq/rq/blob/master/rq/registry.py#L53

**Case to fix**
```
>ttl=None
>ttl if ttl < 0 else 123456 + ttl
None
```
**Other Cases**
```
>ttl=0
>ttl if ttl < 0 else 123456 + ttl
0
>ttl=-1
>ttl if ttl < 0 else 123456 + ttl
-1
>ttl=1
>ttl if ttl < 0 else 123456 + ttl
123457
```