### PR TITLE
Fix default ttl and daemon

### DIFF
--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -107,5 +107,5 @@ class AutoWorker(object):
             mp.Process(target=self._create_worker) for _ in range(0, max_procs)
         ]
         for proc in self.processes:
-            proc.daemon = True
+            proc.daemon = False
             proc.start()

--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -1,5 +1,6 @@
 import os
 import multiprocessing as mp
+from uuid import uuid4
 
 from redis import Redis
 from rq.defaults import DEFAULT_RESULT_TTL
@@ -85,12 +86,12 @@ class AutoWorker(object):
         else:
             exception_handlers = None
 
+        name = '{}-auto'.format(uuid4().hex)
         worker = worker_class(
-            [self.queue], connection=self.connection,
+            [self.queue], name=name, connection=self.connection,
             exception_handlers=exception_handlers,
             default_result_ttl=self.default_result_ttl
         )
-        worker._name = '{}-auto'.format(worker.name)
         worker.work(burst=True)
 
     def _create_worker(self):

--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -1,7 +1,8 @@
 import os
 import multiprocessing as mp
 
-from redis import StrictRedis
+from redis import Redis
+from rq.defaults import DEFAULT_RESULT_TTL
 from rq.contrib.legacy import cleanup_ghosts
 from rq.queue import Queue
 from rq.worker import Worker, WorkerStatus
@@ -43,7 +44,7 @@ class AutoWorker(object):
     :param max_procs: Number of max_procs to spawn
     """
     def __init__(self, queue=None, max_procs=None, skip_failed=True,
-                 default_result_ttl=None):
+                 default_result_ttl=DEFAULT_RESULT_TTL):
         if queue is None:
             queue = 'default'
         if max_procs is None:
@@ -62,7 +63,7 @@ class AutoWorker(object):
         )
         self.skip_failed = skip_failed
         self.default_result_ttl = default_result_ttl
-        self.connection = StrictRedis.from_url(self.config['redis_url'])
+        self.connection = Redis.from_url(self.config['redis_url'])
         queue_class = import_attribute(self.config['queue_class'])
         self.queue = queue_class(queue, connection=self.connection)
 

--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+from __future__ import unicode_literals
 import os
 import multiprocessing as mp
 from uuid import uuid4


### PR DESCRIPTION
- Use default TTL from RQ
- Fix daemon to False
- Pass workername to argument (more compatible with base library)
- Use `unicode_literals` more compatiblity with python3