### PR TITLE
Get MAX_PROCS from cpus and system load average

### DIFF
--- a/autoworker/__init__.py
+++ b/autoworker/__init__.py
@@ -14,7 +14,7 @@ from rq.utils import import_attribute
 from osconf import config_from_environment
 
 
-MAX_PROCS = mp.cpu_count() + 1
+MAX_PROCS = max(mp.cpu_count() - os.getloadavg()[0], 0) + 1
 """Number of maximum procs we can run
 """
 


### PR DESCRIPTION
If the system is in a hard load status, we get the max number of the cpus from the system load average